### PR TITLE
fix: Update build github action and jetty-client vulnerability

### DIFF
--- a/.github/workflows/github-build-release.yml
+++ b/.github/workflows/github-build-release.yml
@@ -12,15 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          java-version: 8
+          distribution: 'temurin'
       - name: Get java-version
         run: |
           BUILD_VERSION=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )
-          echo "::set-env name=VERSION::$BUILD_VERSION"
+          echo "VERSION=$BUILD_VERSION" >> $GITHUB_ENV
       - name: Build
         run: mvn package
       - name: Create Release
@@ -33,8 +34,8 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset 
+      - name: Upload Release Asset With Dependencies
+        id: upload-release-asset-with-dependencies
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -42,4 +43,14 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./target/kafka-connect-elastic-sink-${{env.VERSION}}-jar-with-dependencies.jar
           asset_name: kafka-connect-elastic-sink-${{env.VERSION}}-jar-with-dependencies.jar
+          asset_content_type: application/java-archive
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./target/kafka-connect-elastic-sink-${{env.VERSION}}.jar
+          asset_name: kafka-connect-elastic-sink-${{env.VERSION}}.jar
           asset_content_type: application/java-archive

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
     	<groupId>org.eclipse.jetty</groupId>
     	<artifactId>jetty-client</artifactId>
-    	<version>9.4.26.v20200117</version>
+    	<version>9.4.51.v20230217</version>
     </dependency>
     <dependency>
     	<groupId>org.json</groupId>


### PR DESCRIPTION
- Update set-env way to setting environment variables.
- Update java to version 8 distribution temurin
- Add a additional asset kafka-connect-elastic-sink-VERSION.jar
- fix the vulnerability (CVE-2022-2047) with org.eclipse.jetty:jetty-client: 9.4.26.v20200117 by updating it to 9.4.51.v20230217

![image](https://user-images.githubusercontent.com/17215044/226573715-10aed394-ed49-434a-8b85-7a926491825c.png)

![image](https://user-images.githubusercontent.com/17215044/226573739-bd4a4c4a-88e3-4250-98a4-4be7bd8d035b.png)
