### PR TITLE
Dump the response payload on Elasticsearch errors

### DIFF
--- a/src/main/java/com/ibm/eventstreams/connect/elasticsink/ElasticWriter.java
+++ b/src/main/java/com/ibm/eventstreams/connect/elasticsink/ElasticWriter.java
@@ -327,6 +327,11 @@ public class ElasticWriter {
                 throw new RetriableException(responseString);
             }
 
+            final JSONObject esResponse = new JSONObject(response.getContentAsString());
+            if (esResponse.getBoolean("errors")) {
+                log.error("Elasticsearch returned errors: {}", esResponse);
+            }
+
             // After a success, reset the number of failures.
             commitFailures = 0;
         }


### PR DESCRIPTION
The connector now dumps the response payload if
Elasticsearch had any errors ingesting the events. 
The Elasticsearch payload will be visible in the
Kafka Connect worker logs at an `ERROR` log level.