### PR TITLE
Updated the quickstart test:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,13 +65,13 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
-      <version>2.0.13</version>
+      <version>1.7.36</version>
       <scope>test</scope>
     </dependency>
     <dependency>
     	<groupId>org.eclipse.jetty</groupId>
     	<artifactId>jetty-client</artifactId>
-    	<version>12.0.8</version>
+    	<version>9.4.53.v20231009</version>
     </dependency>
     <dependency>
     	<groupId>org.json</groupId>

--- a/quickstart/Dockerfile
+++ b/quickstart/Dockerfile
@@ -1,4 +1,4 @@
-FROM strimzi/kafka:latest-kafka-3.6.1 as kafka
+FROM quay.io/strimzi/kafka:latest-kafka-3.6.1 as kafka
 
 FROM ibm-semeru-runtimes:open-17-jre
 

--- a/quickstart/Dockerfile
+++ b/quickstart/Dockerfile
@@ -1,6 +1,6 @@
-FROM strimzi/kafka:latest-kafka-2.6.0 as kafka
+FROM strimzi/kafka:latest-kafka-3.6.1 as kafka
 
-FROM ibmjava:8-jre
+FROM ibm-semeru-runtimes:open-17-jre
 
 RUN addgroup --gid 5000 --system esgroup && \
     adduser --uid 5000 --ingroup esgroup --system esuser

--- a/quickstart/README-QS.md
+++ b/quickstart/README-QS.md
@@ -35,7 +35,7 @@ For example, you could run `docker-compose logs connector` to look at the
 log files for one of the containers.
 
 If you want to see the documents that have been put into Elasticsearch, you can
-use the Kibana instance by pointing a browser at http://localhost:5601.
+use the Elasticsearch REST api with the command `curl http://localhost:9200/essinktest/_search`.
 
 When you want to stop the containers, run `docker-compose --project-name qs down`.
 

--- a/quickstart/RUNME.sh
+++ b/quickstart/RUNME.sh
@@ -33,6 +33,10 @@
 curdir=`pwd`
 rc=0
 
+if [ -z "$DOCKER_EXEC" ]; then
+  DOCKER_EXEC="docker"
+fi
+
 cd ..
 
 # Compile the code
@@ -43,7 +47,7 @@ then
 fi
 
 # Build the generated connector jar into a container
-docker build --rm -t kafka-connect-elastic-sink:latest -f quickstart/Dockerfile .
+${DOCKER_EXEC} build --rm -t kafka-connect-elastic-sink:latest -f quickstart/Dockerfile .
 if [ $? -ne 0 ]
 then
   exit 1

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -2,32 +2,15 @@ version: '3'
 
 services:
   elastic:
-    image: elasticsearch:7.6.0
-    environment:
-    - discovery.type=single-node
-    - ELASTICSEARCH_PASSWORD=passw0rd
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
     ports:
-    - "9200:9200"
-    - "9300:9300"
-    #Uncomment these and modify host path if you want persistent data
-    #volumes:
-    #  - '/var/docker/elasticsearch:/usr/share/elasticsearch/data'
-
-  kibana:
-    image: docker.elastic.co/kibana/kibana:7.6.0
-    depends_on: 
-    - elastic
-    ports:
-    - "5601:5601"
+      - ${ES_PORT}:9200
     environment:
-    - ELASTICSEARCH_HOSTS=http://elastic:9200
-    - ELASTICSEARCH_USERNAME=elastic
-    #Uncomment these and modify host path if you want persistent data
-    #volumes:
-    #  - '/var/docker/kibana:/usr/share/kibana/data'
+      - discovery.type=single-node
+      - xpack.security.enabled=false
 
   zookeeper:
-    image: strimzi/kafka:latest-kafka-2.5.0
+    image: quay.io/strimzi/kafka:latest-kafka-3.6.1
     command: [
         "sh", "-c",
         "bin/zookeeper-server-start.sh config/zookeeper.properties"
@@ -38,7 +21,7 @@ services:
       LOG_DIR: /tmp/logs
 
   kafka:
-    image: strimzi/kafka:latest-kafka-2.5.0
+    image: quay.io/strimzi/kafka:latest-kafka-3.6.1
     command: [
       "sh", "-c",
       "bin/kafka-server-start.sh config/server.properties --override listeners=$${KAFKA_LISTENERS} --override advertised.listeners=$${KAFKA_ADVERTISED_LISTENERS} --override zookeeper.connect=$${KAFKA_ZOOKEEPER_CONNECT}"
@@ -63,4 +46,3 @@ services:
     environment:
     - CONNECT_BOOTSTRAP_SERVERS=kafka:9092
     - CONNECT_ES_CONNECTION=elastic:9200
-    #network_mode: "host"

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -2,9 +2,9 @@ version: '3'
 
 services:
   elastic:
-    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
     ports:
-      - ${ES_PORT}:9200
+      - 9200:9200
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false

--- a/src/main/java/com/ibm/eventstreams/connect/elasticsink/ElasticWriter.java
+++ b/src/main/java/com/ibm/eventstreams/connect/elasticsink/ElasticWriter.java
@@ -28,15 +28,13 @@ import java.util.concurrent.TimeUnit;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.eclipse.jetty.client.AuthenticationStore;
-import org.eclipse.jetty.client.BasicAuthentication;
-import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpProxy;
-import org.eclipse.jetty.client.StringRequestContent;
-import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;
+import org.eclipse.jetty.client.api.AuthenticationStore;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.util.BasicAuthentication;
+import org.eclipse.jetty.client.util.StringContentProvider;
 import org.eclipse.jetty.http.HttpMethod;
-import org.eclipse.jetty.io.ClientConnector;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -312,7 +310,7 @@ public class ElasticWriter {
             response = httpClient.newRequest(destination)
                                  .timeout(jettyOperationTimeoutSec, TimeUnit.SECONDS)
                                  .method(HttpMethod.POST)
-                                 .body(new StringRequestContent("application/json", bulkMsg.toString()))
+                                 .content(new StringContentProvider(bulkMsg.toString()), "application/json")
                                  .send();
 
             // Always empty the request batch, even after a failure as the Connector framework
@@ -512,11 +510,8 @@ public class ElasticWriter {
         // Set the Protocols and CipherSuites that are permitted
         setDefaults(sslContextFactory);
 
-        ClientConnector clientConnector = new ClientConnector();
-        clientConnector.setSslContextFactory(sslContextFactory);
-
         if (protocol.equals("https"))
-            httpClient = new HttpClient(new HttpClientTransportDynamic(clientConnector));
+            httpClient = new HttpClient(sslContextFactory);
         else
             httpClient = new HttpClient();
 


### PR DESCRIPTION
* Updated the `quickstart` dependencies to use the latest Kafka and Elasticsearch images.
* Updated the Java runtime from Java 8 to Java 17.
* Aligned the dependency versions of Jetty and slf4j to match the versions in the Kafka distribution.
* Removed Kabana from the `docker-compose` and added an instruction on how to read the Elasticsearch content with a REST api
* Added an envar to `RUNME.sh` to allow alternatives to Docker be used