### PR TITLE
fix: CVE-2024-6763 - vulnerable version jetty-http-9.4.53.v20231009 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
     	<groupId>org.eclipse.jetty</groupId>
     	<artifactId>jetty-client</artifactId>
-    	<version>9.4.53.v20231009</version>
+    	<version>9.4.57.v20241219</version>
     </dependency>
     <dependency>
     	<groupId>org.json</groupId>


### PR DESCRIPTION
https://www.mend.io/vulnerability-database/CVE-2024-6763

Contributes-to: https://jsw.ibm.com/browse/EVI-12843